### PR TITLE
Moving of Duplicates and summarization of output

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,12 @@ TODO
 * [x] Find duplicates
 * [ ] Take action
     * Interactive actions
-        * For interactive action open them in text editor
-    * Delete All duplicates
-    * Copy to another directory
+        * [x] Open in text editor
+    * [x] Delete All duplicates
+    * [x] Move to another directory
+* [ ] Improve output display
+* [ ] Additional useful information on summary
+    * [ ] Like percentage of path consumed by duplicates
 
 Contributing
 ------------

--- a/py_duplicates.py
+++ b/py_duplicates.py
@@ -34,7 +34,10 @@ def parse_args():
                         '--summary',
                         action='store_true',
                         help="display summary of duplicate search")
-
+    parser.add_argument('-m',
+                        '--move',
+                        metavar='DIR',
+                        help="move all duplicates to another directory")
 
     args = parser.parse_args()
     return args
@@ -145,6 +148,24 @@ def delete_all_duplicates(hash_file_dict):
                 os.remove(dup)
     print ("All duplicate files are deleted.")
 
+def move_duplicates(hash_file_dict, dirname):
+    """Move duplicates to location specified by parameter dirname
+
+    :hash_file_dict: dictionary, contains hash:files
+    :dirname: location on where to transfer duplicates
+    :returns: None
+
+    """
+    if not os.path.isdir(dirname):
+        print("Invalid Directory {}. Aborted.".format(dirname))
+        return
+
+    for k, v in hash_file_dict.items():
+        if len(v) > 1:
+            for dup in v:
+                os.rename(dup, os.path.join(dirname, os.path.basename(dup)))
+    print ("All duplicate files are moved to {}.".format(dirname))
+
 def open_file(filename):
     """Opens file using default programs
     :filename: filename of the file to be openned
@@ -182,9 +203,9 @@ def interactive_mode(hash_file_dict):
             for i, dup in enumerate(v):
                 print("Duplicate {}: {}".format(i, dup))
                 while True:
-                    action = input("[s]kip, [d]elete, [o]pen [r]ename > ")\
+                    action = input("[s]kip [d]elete [o]pen [r]ename [m]ove > ")\
                         .lower()
-                    if action in "sdor" and len(action) == 1:
+                    if action in "sdorm" and len(action) == 1:
                         if action == "s":
                             break
                         elif action == "d":
@@ -198,6 +219,14 @@ def interactive_mode(hash_file_dict):
                             newname = input("new name > ")
                             os.rename(dup,
                                 os.path.join(os.path.dirname(dup), newname))
+                            break
+                        elif action == "m":
+                            while True:
+                                destdir = input("directory name > ")
+                                if os.path.isdir(destdir):
+                                    break
+                            os.rename(dup,
+                                os.path.join(destdir, os.path.basename(dup)))
                             break
 
 
@@ -218,3 +247,5 @@ if __name__ == "__main__":
         print("** summary **")
         print("{dupcount} files have duplicates, having a total of \
 {duptotal} duplicate files.\n{empty} files are empty.".format(**summary))
+    elif args.move:
+        move_duplicates(hash_file_dict, args.move)

--- a/py_duplicates.py
+++ b/py_duplicates.py
@@ -30,6 +30,10 @@ def parse_args():
                         '--interactive',
                         action='store_true',
                         help="interactively manage duplicates")
+    parser.add_argument('-s',
+                        '--summary',
+                        action='store_true',
+                        help="display summary of duplicate search")
 
 
     args = parser.parse_args()
@@ -109,6 +113,24 @@ def get_duplicates(hash_file_dict):
         # Print them #
         if len(v) > 1:
             print ("Duplicate Files => {}".format(', '.join(v)))
+
+def summarize_duplicates(hash_file_dict):
+    """Summarize file duplicate searching
+
+    :hash_file_dict: dictionary, contains hash:files
+    :returns: dictionary containing the search summary
+
+    """
+    summary = { 'dupcount' : 0,     # number of unique files with duplicates
+                'empty' : 0,        # number of empty files
+                'duptotal' : 0 }    # overall number of duplicate files
+    for k, v in hash_file_dict.items():
+        if len(v) > 1:
+            summary['dupcount'] += 1
+            summary['duptotal'] += len(v)
+            if os.stat(v[0]).st_size == 0:
+                summary['empty'] += len(v)
+    return summary
 
 def delete_all_duplicates(hash_file_dict):
     """Delete all files with duplicates
@@ -191,3 +213,8 @@ if __name__ == "__main__":
         delete_all_duplicates(hash_file_dict)
     elif args.interactive:
         interactive_mode(hash_file_dict)
+    elif args.summary:
+        summary = summarize_duplicates(hash_file_dict)
+        print("** summary **")
+        print("{dupcount} files have duplicates, having a total of \
+{duptotal} duplicate files.\n{empty} files are empty.".format(**summary))


### PR DESCRIPTION
Instead of the proposed copying of duplicates, I thought that moving would be more practical as copying just creates more duplicates.

I added an additional functionality which displays the summary of the duplicate search in the directory. This might be useful to some users. This can also be extended as I've indicated in the readme.

Oh, and I don't know how to format [this particular line](https://github.com/excal04/py_duplicates/blob/master/py_duplicates.py#L249) so that it wouldn't indent. Not sure if it follows PEP.
